### PR TITLE
chore : add types/node in devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@masatomakino/gulptask-demo-page": "^0.8.0",
+        "@types/node": "^22.5.4",
         "@types/three": "^0.168.0",
         "@vitest/coverage-istanbul": "^2.0.5",
         "browser-sync": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "devDependencies": {
     "@masatomakino/gulptask-demo-page": "^0.8.0",
+    "@types/node": "^22.5.4",
     "@types/three": "^0.168.0",
     "@vitest/coverage-istanbul": "^2.0.5",
     "browser-sync": "^3.0.2",


### PR DESCRIPTION
types/nodeは*指定でインストールされるため、dependabotによって更新されない。